### PR TITLE
Server Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ npx @streamerjs/streamerjs create-control-panel index.html
 
 The page will include the control panel HTML, CSS and JavaScript files and will use PouchDB to synchronize with the [scenes](#scenes).
 
+## Server Scripts
+
+You can now create server-side scripts in the `/server/` folder. These scripts can be used to customize the behavior of the Streamer JS application when it starts and has access to `db` object to initialize the application or to react to changes.
+
+To enable scripts, create a `/server/scripts.mjs` file with `init()` function that takes an object with `db` property.
+
+Here's an example:
+
+```javascript
+// sample `server/scripts.mjs` logging current state
+// of a document in the database on startup
+export function init({ db }) {
+  db.get("my_scene")
+    .then(function (doc) {
+      console.log("Current my_scene document:", doc);
+    })
+    .catch(function (err) {
+      console.error("Error fetching my_scene document:", err);
+    });
+}
+```
+
+Scripts currently can't be called directly from the client, unless you somehow pass messages through a DB queue document making scripts listen to database changes, picking up and processing those messages.
+
+We hope to implement this kind of RPC functionality soon so you don't have to jump through hoops to accomplish that.
+
 ## Help
 
 To get help, run the following command:

--- a/cli.js
+++ b/cli.js
@@ -157,9 +157,11 @@ function start() {
 
   app.use("/assets/", express.static("assets"));
 
+  let liveReloadServer;
+
   if (config.livereload) {
     // Setup livereload
-    const liveReloadServer = livereload.createServer();
+    liveReloadServer = livereload.createServer();
 
     // Use connect-livereload middleware
     app.use(connectLivereload());

--- a/cli.js
+++ b/cli.js
@@ -140,7 +140,7 @@ async function registerServerScripts(db) {
   }
 
   if (scripts.init) {
-    scripts.init(db);
+    scripts.init({ db });
   }
 }
 
@@ -148,14 +148,6 @@ function start() {
   const insecurePort = config.port || process.env.PORT;
 
   const app = express();
-  // Scenes in user's project
-  app.use(
-    "/scenes/",
-    express.static("scenes"),
-    serveIndex("scenes", { icons: true })
-  );
-
-  app.use("/assets/", express.static("assets"));
 
   let liveReloadServer;
 
@@ -166,6 +158,19 @@ function start() {
     // Use connect-livereload middleware
     app.use(connectLivereload());
 
+    console.log("Livereloadis server started");
+  }
+
+  // Scenes in user's project
+  app.use(
+    "/scenes/",
+    express.static("scenes"),
+    serveIndex("scenes", { icons: true })
+  );
+
+  app.use("/assets/", express.static("assets"));
+
+  if (liveReloadServer) {
     liveReloadServer.watch("./scenes/");
 
     // Assets in user's project
@@ -173,7 +178,6 @@ function start() {
 
     console.log("Livereload enabled for /scenes/ and /assets/ folders");
   }
-
   // streamer resources
   const templates = url.fileURLToPath(import.meta.resolve("./templates/"));
   app.set("view engine", "ejs").set("views", templates);

--- a/cli.js
+++ b/cli.js
@@ -158,7 +158,7 @@ function start() {
     // Use connect-livereload middleware
     app.use(connectLivereload());
 
-    console.log("Livereloadis server started");
+    console.log("Livereload server started");
   }
 
   // Scenes in user's project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamerjs/streamerjs",
-  "version": "1.0.10",
+  "version": "1.0.10-scripts",
   "description": "Video stream layout manager",
   "main": "./cli.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamerjs/streamerjs",
-  "version": "1.0.10-scripts",
+  "version": "1.1.0",
   "description": "Video stream layout manager",
   "main": "./cli.js",
   "repository": {


### PR DESCRIPTION
This allows projects to define server scripts that will be ran when server starts.

Currently it only runs "init()" script to kick-off server code execution.

Script can manipulate the database and can react to the database being manipulated by listening to the database changes.

There is no specific way to invoke the script from a control page however (unless you kick it off by listening to a particular db change).